### PR TITLE
Fix timezone handling for Lux, Porto Astra, and The Space Cinema scrapers

### DIFF
--- a/scripts/cinemas/luxCinema.ts
+++ b/scripts/cinemas/luxCinema.ts
@@ -163,7 +163,7 @@ export async function scraper(): Promise<CinemaShowing[]> {
         // Add showing to existing film entry
         const filmEntry = filmMap.get(filmKey)!;
         filmEntry.showings.push({
-            startTime: new Date(event.start_date).toISOString(), // utc_start_date also available
+            startTime: event.utc_start_date + '+0', // +0 for the timezone
             bookingUrl: `https://www.liveticket.it/cinemaluxpadova#EventsTitleAnchor`, // no way to access the real url
         });
     });

--- a/scripts/cinemas/portoAstraCinema.ts
+++ b/scripts/cinemas/portoAstraCinema.ts
@@ -1,90 +1,90 @@
 import type { Cinema, CinemaShowings, Showing } from '../types';
+import { setTimeZone } from '../utils';
 
 export interface APIResponse {
     userdata: Userdata;
-    DS:       Ds;
-}    
+    DS: Ds;
+}
 
 export interface Ds {
-    Scheduling:    Scheduling;
+    Scheduling: Scheduling;
     OptinRequired: boolean;
-    TicketoFound:  boolean;
-}    
+    TicketoFound: boolean;
+}
 
 export interface Scheduling {
-    LocalId:  number;
+    LocalId: number;
     LogoPath: string;
-    Events:   Event[];
-}    
+    Events: Event[];
+}
 
 export interface Event {
-    EventId:         number;
-    Title:           string;
-    OriginalTitle:   string;
-    Description:     string;
-    Actors:          string;
-    Type:            Type;
-    Is3D:            boolean;
-    Director:        string;
-    Duration:        string;
-    Picture:         string;
-    Year:            string;
-    Category:        string;
-    MovieId:         string;
-    TitleId:         string;
-    Properties:      string[];
+    EventId: number;
+    Title: string;
+    OriginalTitle: string;
+    Description: string;
+    Actors: string;
+    Type: Type;
+    Is3D: boolean;
+    Director: string;
+    Duration: string;
+    Picture: string;
+    Year: string;
+    Category: string;
+    MovieId: string;
+    TitleId: string;
+    Properties: string[];
     EventProperties: EventProperty[];
-    Days:            Day[];
-    IsStreaming:     boolean;
-}    
+    Days: Day[];
+    IsStreaming: boolean;
+}
 
 export interface Day {
     GroupedByScreen: boolean;
-    Performances:    Performance[];
-    Day:             Date;
-}    
+    Performances: Performance[];
+    Day: Date;
+}
 
 export interface Performance {
     PerformanceId: number;
-    Time:          string;
-    Screen:        Screen;
-    ScreenId:      number;
-    StartTime:     Date;
-    EndTime:       Date;
-    Duration:      number;
-}    
+    Time: string;
+    Screen: Screen;
+    ScreenId: number;
+    StartTime: Date;
+    EndTime: Date;
+    Duration: number;
+}
 
 export enum Screen {
-    Sala1 = "SALA 1",
-    Sala2 = "SALA 2",
-    Sala3 = "SALA 3",
-    Sala4 = "SALA 4",
-    Sala5 = "SALA 5",
-    Sala6 = "SALA 6",
-    Sala7 = "SALA 7",
-}    
+    Sala1 = 'SALA 1',
+    Sala2 = 'SALA 2',
+    Sala3 = 'SALA 3',
+    Sala4 = 'SALA 4',
+    Sala5 = 'SALA 5',
+    Sala6 = 'SALA 6',
+    Sala7 = 'SALA 7',
+}
 
 export interface EventProperty {
-    EventProperty:         string;
+    EventProperty: string;
     EventPropertyCategory: string;
-}    
+}
 
 export enum Type {
-    Cinema = "CINEMA",
-}    
+    Cinema = 'CINEMA',
+}
 
 export interface Userdata {
-    StatusOk:   boolean;
+    StatusOk: boolean;
     ReasonCode: number;
-    Message:    string;
+    Message: string;
     StackTrace: string;
-    Elapsed:    number;
-    StartTime:  Date;
-    EndTime:    Date;
-    TimeTrace:  string[];
-    Errors:     any[];
-}    
-
+    Elapsed: number;
+    StartTime: string; // Date?
+    EndTime: Date;
+    TimeTrace: string[];
+    Errors: any[];
+}
 
 // all info at https://secure.webtic.it/api/wtjsonservices.ashx?languageid=it&localid=5082&trackid=33&wtid=getLocalInfo
 const CINEMA: Cinema = {
@@ -94,7 +94,7 @@ const CINEMA: Cinema = {
         lat: '45.38365',
         lng: '11.8656',
     },
-    defaultLanguage: 'it-IT'
+    defaultLanguage: 'it-IT',
 };
 
 const LOG_PREFIX = '[' + CINEMA.name + ']';
@@ -102,10 +102,20 @@ const API_URL =
     'https://secure.webtic.it/api/wtjsonservices.ashx?localid=5082&trackid=33&wtid=getFullScheduling';
 const BASE_URL = 'https://portoastra.it';
 const IMAGE_BASE_URL = 'https://secure.webtic.it/angwt/';
+const DEFAULT_TIME_ZONE = 'Europe/Rome';
 
 export async function scraper(): Promise<CinemaShowings> {
     const res = await fetch(API_URL);
+    if (!res.ok) {
+        console.warn(
+            `${LOG_PREFIX} The request to WebTic API gave response code: `,
+            res.status
+        );
+        return []; // This returns an empty list of movies so the getData script won't be stopped in case of an error
+    }
     const json = (await res.json()) as APIResponse;
+
+    const timezone = json.userdata.StartTime.match(/[+-]\d{2}:?\d{2}$/)?.[0];
 
     return [
         {
@@ -133,9 +143,12 @@ export async function scraper(): Promise<CinemaShowings> {
                     day.Performances.map(
                         (showing) =>
                             ({
-                                startTime: new Date(
-                                    showing.StartTime
-                                ).toISOString(),
+                                startTime: timezone
+                                    ? showing.StartTime + timezone
+                                    : setTimeZone(
+                                          showing.StartTime,
+                                          DEFAULT_TIME_ZONE
+                                      ),
                                 theatre: showing.Screen,
                                 bookingUrl: `http://www.webtic.it/mobile/?trackid=41&action=loadPerformance&localId=${json.DS.Scheduling.LocalId}&eventId=${event.EventId}&performanceId=${showing.PerformanceId}`,
                             }) as Showing

--- a/scripts/cinemas/theSpaceCinema.ts
+++ b/scripts/cinemas/theSpaceCinema.ts
@@ -9,8 +9,159 @@ import type {
 const CINEMA: Cinema = {
     name: 'The Space Cinema Limena',
     location: 'Padova',
-    defaultLanguage: 'en-GB',
+    defaultLanguage: 'it-IT',
 };
+
+
+export interface TheSpaceAPIResponse {
+    result:       Result[];
+    responseCode: number;
+    errorMessage: null;
+}
+
+export interface Result {
+    showingGroups:              ShowingGroup[];
+    filmId:                     string;
+    certificate:                Certificate;
+    secondaryCertificates:      Certificate[];
+    filmUrl:                    string;
+    filmAttributes:             Attribute[];
+    posterImageSrc:             string;
+    cast:                       string;
+    releaseDate:                Date;
+    runningTime:                number;
+    isDurationUnknown:          boolean;
+    synopsisShort:              string;
+    filmTitle:                  string;
+    hasSessions:                boolean;
+    hasTrailer:                 boolean;
+    embargoMessage:             string;
+    embargoEndDate:             Date | null;
+    embargoLevel:               null;
+    priceMessage:               PriceMessage | null;
+    alternativeCertificate:     Certificate;
+    panelImageUrl:              string;
+    filmStatus:                 number;
+    trailers:                   any[];
+    director:                   string; // could be ""
+    distributor:                string;
+    movieXchangeCode:           string;
+    crossCountryMovieXchangeId: string;
+    originalTitle:              string; // almost always ""
+    showingInCinemas:           string[];
+    genres:                     string[];
+    sessionAttributes:          any[];
+}
+
+export interface Certificate {
+    name:        null | string;
+    description: Description | null;
+    src:         null | string;
+}
+
+export enum Description {
+    Alcol = "Alcol",
+    Armi = "Armi",
+    Discriminazione = "Discriminazione",
+    Empty = "",
+    Sesso = "Sesso",
+    Torpiloquio = "Torpiloquio",
+    Violenza = "Violenza",
+}
+
+export interface Attribute {
+    name:               Name;
+    shortName:          Name;
+    value:              Name;
+    description:        string;
+    attributeType:      AttributeType;
+    color:              Color;
+    borderGradient:     any[] | null;
+    backgroundImageUrl: null;
+    iconName:           null;
+}
+
+export enum AttributeType {
+    Language = "Language",
+    Movie = "Movie",
+    Session = "Session",
+    SessionSpecial = "Session_Special",
+}
+
+export enum Color {
+    Empty = "",
+    F7941E = "#f7941e",
+}
+
+export enum Name {
+    BackOnTheBigScreen = "BACK ON THE BIG SCREEN",
+    CanzoniInInglese = "CANZONI IN INGLESE",
+    Cinemapark = "CINEMAPARK",
+    DirettaLive = "DIRETTA LIVE",
+    Empty = "",
+    Epic = "EPIC",
+    Extra = "EXTRA",
+    Italiano = "ITALIANO",
+    LinguaOriginale = "LINGUA ORIGINALE",
+    ProiezioneLASER = "Proiezione LASER",
+    ProiezioneLASER4K = "Proiezione LASER 4K",
+    The2D = "2D",
+    The3D = "3D",
+}
+
+export enum PriceMessage {
+    The1InMenoSEAcquistiOnline = "1€ in meno se acquisti online",
+}
+
+export interface ShowingGroup {
+    date:         Date;
+    datePrefix:   DatePrefix;
+    pricingTypes: any[];
+    sessions:     Session[];
+}
+
+export enum DatePrefix {
+    Domani = "Domani",
+    Empty = "",
+    Oggi = "Oggi",
+}
+
+export interface Session {
+    sessionId:                   string;
+    bookingUrl:                  string;
+    formattedPrice:              string; // i.e. "12,09 €"
+    isPriceVisible:              boolean;
+    duration:                    number;
+    startTime:                   Date;
+    endTime:                     Date;
+    showTimeWithTimeZone:        string; // Date?
+    isSoldOut:                   boolean;
+    color:                       null;
+    isMidnightSession:           boolean;
+    isBookingAvailable:          boolean;
+    attributes:                  Attribute[];
+    screenName:                  ScreenName;
+    sessionPricingDisplayStatus: number;
+    wheelchairSeatAvailability:  number;
+}
+
+export enum ScreenName {
+    Sala1 = "Sala 1",
+    Sala10 = "Sala 10",
+    Sala11 = "Sala 11",
+    Sala12 = "Sala 12",
+    Sala13 = "Sala 13",
+    Sala14 = "Sala 14",
+    Sala2 = "Sala 2",
+    Sala3 = "Sala 3",
+    Sala4 = "Sala 4",
+    Sala5 = "Sala 5",
+    Sala6 = "Sala 6",
+    Sala7 = "Sala 7",
+    Sala8 = "Sala 8",
+    Sala9 = "Sala 9",
+}
+
 
 // Extended interfaces for additional fields
 interface SpaceFilmData extends Film {
@@ -26,38 +177,6 @@ interface SpaceShowingData extends Showing {
     _price?: number; // Stored for future use
 }
 
-// Interfaces for the API response
-interface SpaceAttribute {
-    name: string;
-    value: string;
-    attributeType: string;
-}
-
-interface SpaceSession {
-    startTime: string;
-    endTime?: string;
-    bookingUrl?: string;
-    screenName?: string;
-    attributes: SpaceAttribute[];
-    formattedPrice?: string;
-    isPriceVisible?: boolean;
-}
-
-interface SpaceFilm {
-    filmTitle: string;
-    filmId: string;
-    runningTime?: number;
-    director?: string;
-    posterImageSrc?: string;
-    originalTitle?: string;
-    cast?: string;
-    synopsisShort?: string;
-    genres?: string[];
-    releaseDate?: string;
-    showingGroups: Array<{
-        sessions: SpaceSession[];
-    }>;
-}
 
 const CINEMA_NAME = 'The Space Cinema';
 const LOG_PREFIX = '[' + CINEMA_NAME + ']';
@@ -90,10 +209,10 @@ export async function scraper(cinema: number = 1012): Promise<CinemaShowing[]> {
         return []; // This returns an empty list of movies so the getData script won't be stopped in case of an error
     }
 
-    const data = await response.json();
+    const data = await response.json() as TheSpaceAPIResponse;
 
     // Transform API response into FilmShowings format (group by film)
-    const filmShowings: FilmShowings[] = data.result.map((film: SpaceFilm) => {
+    const filmShowings: FilmShowings[] = data.result.map((film) => {
         // Extract year from release date if available
         const releaseYear = film.releaseDate
             ? new Date(film.releaseDate).getFullYear()
@@ -111,7 +230,7 @@ export async function scraper(cinema: number = 1012): Promise<CinemaShowing[]> {
             title: film.filmTitle,
             url: `https://www.thespacecinema.it/film/${film.filmId}`,
             duration: film.runningTime,
-            director: film.director,
+            director: film.director || undefined, // undefined in place of ''
             coverUrl: film.posterImageSrc,
             genres: film.genres,
             originalTitle: film.originalTitle,
@@ -126,7 +245,7 @@ export async function scraper(cinema: number = 1012): Promise<CinemaShowing[]> {
             showings: film.showingGroups.flatMap((day) =>
                 day.sessions.map((show) => {
                     const showing: SpaceShowingData = {
-                        startTime: show.startTime,
+                        startTime: show.showTimeWithTimeZone,
                         theatre: show.screenName,
                         bookingUrl: show.bookingUrl
                             ? `https://www.thespacecinema.it${show.bookingUrl}`

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -196,3 +196,17 @@ export async function fetchAndParseICS<T = unknown>(
 
     return events;
 }
+
+/**
+ * ## Add timezone to a timestamp without one
+ * A function that sets the timezone on a date without one, and returns the date in ISO format
+ * @param date the date to be converted to ISO format
+ * @param timezone timezone in the standard form "Europe/Rome", or "+01", etc.
+ * @returns the corresponding ISO string after setting the appropriate timezone
+ */
+export function setTimeZone(date: Date | string, timezone: string): string {
+    const tzDate = new Date(
+        new Date(date).toLocaleString('en-US', { timeZone: timezone })
+    );
+    return tzDate.toISOString();
+}


### PR DESCRIPTION
- Lux: use utc_start_date field directly with +0 offset
- Porto Astra: extract timezone from API response, fallback to setTimeZone util; add error handling for failed API requests
- The Space: use showTimeWithTimeZone field for accurate start times; replace ad-hoc interfaces with typed API response; fix language to it-IT
- utils: add setTimeZone helper to apply a named timezone to a timestamp

closes #75 